### PR TITLE
json object decoding

### DIFF
--- a/api.py
+++ b/api.py
@@ -3,13 +3,14 @@ import stat
 class JSONable:
     def toDict(self):
         raise NotImplementedError
-    def fromDict(self):
+    @classmethod
+    def fromDict(cls, data: dict):
         raise NotImplementedError
 
 
 class FileResult(JSONable):
-    def __init__(self, fname: str, content: str, diff: str, perm: int):
-        assert stat.S_IMODE(perm) == perm
+    def __init__(self, fname: str, content: str, diff: str, perm: int = -1):
+        assert perm < 0 or stat.S_IMODE(perm) == perm
         self.fname = fname
         self.content = content
         self.diff = diff
@@ -24,9 +25,14 @@ class FileResult(JSONable):
         }
 
 
-    def fromDict(self):
-        # TODO
-        raise NotImplementedError
+    @classmethod
+    def fromDict(cls, data: dict):
+        cls.fname = data.keys()[0]
+        cls.content = data[cls.fname]['content']
+        cls.diff = data[cls.fname]['diff']
+        cls.perm = data[cls.fname]['perm']
+        assert cls.perm < 0 or stat.S_IMODE(cls.perm) == cls.perm
+        return cls
 
 
 class TCResult(JSONable):
@@ -44,11 +50,13 @@ class TCResult(JSONable):
         self.fio = []           # type: list[FileResult]
 
 
-    def stdout(self, output: str):
+    def stdout(self, output: FileResult):
+        assert output.fname == "stdout"
         self.cio[0] = output
 
 
-    def stderr(self, output: str):
+    def stderr(self, output: FileResult):
+        assert output.fname == "stderr"
         self.cio[1] = output
 
 
@@ -61,10 +69,16 @@ class TCResult(JSONable):
             "result": self.result,
             "etime": self.etime,
             "pstatus": self.pstatus,
-            "cio": self.cio,
+            "cio": {x.fname: x.toDict() for x in self.cio},
             "fio": {x.fname: x.toDict() for x in self.fio}
         }
 
-    def fromDict(self):
-        # TODO
-        raise NotImplementedError
+
+    @classmethod
+    def fromDict(cls, data: dict):
+        cls.result = data["result"]
+        cls.etime = data["etime"]
+        cls.pstatus = data["pstatus"]
+        cls.cio = [FileResult(fname=x, **data["cio"][x]) for x in ("stdout", "stderr")]
+        cls.fio = [FileResult.fromDict({k: v}) for k, v in data["fio"].items()]
+        return cls


### PR DESCRIPTION
TCResult class의 경우 toDict에서 생성한 것과 같은 포맷으로 입력을 받아 TCResult 객체를 생성할 수 있도록 하였습니다.
FileResult class의 경우 toDict에서 받은 결과만으론 fname을 받을 수 없고, 그 용도 자체가 불분명해 우선 TCResult에서 사용하는 형식대로 "fname": 내용 형태의 dictionary를 받아 list[FileResult]를 반환하도록 하였습니다.
work on #3 